### PR TITLE
fix(SDK-1352): derivar cod_respuesta desde el estado de la transaccion

### DIFF
--- a/lib/gateways/msTransactionCash.js
+++ b/lib/gateways/msTransactionCash.js
@@ -427,6 +427,47 @@ var TYPE_BY_FRANCHISE = Object.keys(FRANCHISE_MAP).reduce(function (acc, type) {
 }, {});
 
 /**
+ * `estado`/`status` text (Spanish, case-insensitive) -> legacy `cod_respuesta`
+ * numeric code. Mirrors the equivalent PHP switch already used elsewhere in
+ * the ePayco ecosystem for this exact mapping (status text -> response
+ * code), given by the requester rather than reverse-engineered here.
+ *
+ * Cross-checked against the one real value we've observed both backends
+ * return for the same transaction: ms-transaction's `status: "Pendiente"`
+ * maps to `3` below, which matches the legacy endpoint's own `cod_respuesta:
+ * 3` for that same "Pendiente" transaction (see SDK-1352 QA notes) -- the
+ * other cases (aprobada/rechazada/etc.) are not yet cross-checked against a
+ * real ms-transaction response in that state.
+ *
+ * @param {String} estadoTexto e.g. "Pendiente", "Rechazada"
+ * @return {Number}
+ */
+function codRespuestaFromEstado(estadoTexto) {
+    switch (String(estadoTexto || '').toLowerCase()) {
+        case 'aprobada':
+        case 'aceptada':
+            return 1;
+        case 'rechazada':
+            return 2;
+        case 'pendiente':
+            return 3;
+        case 'fallida':
+            return 4;
+        case 'reversada':
+        case 'reversado':
+            return 6;
+        case 'retenido':
+            return 7;
+        case 'abandonada':
+            return 10;
+        case 'cancelada':
+            return 11;
+        default:
+            return 0;
+    }
+}
+
+/**
  * Map a successful ms-transaction response into the exact response shape the
  * legacy secure.payco.co/restpagos/v2/efectivo/{type} endpoint returns today
  * (see lib/resources/cash.js#_legacyCreate and tests/cash.js's "legacy flow"
@@ -441,11 +482,10 @@ var TYPE_BY_FRANCHISE = Object.keys(FRANCHISE_MAP).reduce(function (acc, type) {
  * that response's `payerInformation` is masked for privacy
  * (e.g. "documentType": "C*"), so it cannot be used to reconstruct them.
  *
- * Known gap (no verified source field in the ms-transaction response,
- * flagged rather than guessed):
- *  - `cod_respuesta` (legacy: numeric, e.g. 3): ms-transaction only exposes
- *    `responseCode` as a string (e.g. "P004", which lines up with legacy's
- *    separate `cod_error` field instead -- see mapping below). Left `null`.
+ * `cod_respuesta` is derived from `data.status` via codRespuestaFromEstado()
+ * above (ms-transaction itself has no numeric equivalent of this field --
+ * only `responseCode`, a string like "P004" that lines up with legacy's
+ * separate `cod_error` field instead, mapped below).
  *
  * `cc_network_response` IS included below despite having no equivalent field
  * in the ms-transaction response at all: two separate real pre-prod calls
@@ -488,7 +528,7 @@ function mapToLegacyShape(raw, options, type) {
             recibo: data.receipt,
             fecha: data.date,
             franquicia: data.franchise,
-            cod_respuesta: null,
+            cod_respuesta: codRespuestaFromEstado(data.status),
             cod_error: data.responseCode,
             ip: data.ip,
             enpruebas: data.testMode,


### PR DESCRIPTION
Cierra el gap documentado anteriormente: cod_respuesta quedaba null porque ms-transaction no expone un codigo numerico equivalente, solo "responseCode" (string, ya mapeado a cod_error).

Se agrega codRespuestaFromEstado(), mapeo texto de estado -> codigo numerico, replicando el switch PHP ya usado en otro punto del ecosistema para esta misma conversion.

Verificado con una transaccion real en pre-prod: status "Pendiente" -> cod_respuesta 3, coincide exactamente con lo que devuelve el endpoint legado para el mismo estado. Los demas casos del switch (aprobada/rechazada/etc.) no estan cruzados aun contra una respuesta real de ms-transaction en ese estado.