### PR TITLE
SDK-1352: usar eks-ms-authentication-service para el login de ms-transaction

### DIFF
--- a/lib/gateways/msTransactionCash.js
+++ b/lib/gateways/msTransactionCash.js
@@ -4,9 +4,10 @@
  * secure.payco.co/restpagos/v2/efectivo/{type} flow used by lib/resources/cash.js.
  *
  * Kept isolated from lib/resources/index.js (Resource#request) on purpose: this
- * flow talks to different hosts, uses a different auth handshake (Basic login
- * against eks-apify-service.epayco.io -> short-lived JWT) and a different
- * per-field AES-256-CBC encryption scheme than the legacy secure.payco.co flow,
+ * flow talks to different hosts, uses a different auth handshake (OAuth2
+ * client_credentials against eks-ms-authentication-service.epayco.io ->
+ * short-lived JWT) and a different per-field AES-256-CBC encryption scheme
+ * than the legacy secure.payco.co flow,
  * so folding it into Resource#request's already-overloaded flag signature
  * (sw/cashData/card/apify) would make that method harder to reason about. This
  * module is also written so the pure body-building/encryption logic can be unit
@@ -35,12 +36,12 @@ var REQUEST_TIMEOUT_MS = 10000;
  * NOTE: this is intentionally NOT the same host as the existing `apify` flag in
  * lib/resources/index.js (BASE_URL_APIFY, default "https://apify.epayco.co",
  * used today by safetypay.js/daviplata.js). The ms-transaction cash flow talks
- * to a different, newer host (eks-apify-service.epayco.io for auth,
- * apiflow.epayco.io for the transaction itself), verified empirically against
- * the real API.
+ * to a different, newer host (eks-ms-authentication-service.epayco.io for
+ * auth, apiflow.epayco.io for the transaction itself), verified empirically
+ * against the real API.
  */
 var BASE_URL_MS_TRANSACTION = process.env.BASE_URL_MS_TRANSACTION || 'https://apiflow.epayco.io';
-var BASE_URL_MS_TRANSACTION_AUTH = process.env.BASE_URL_MS_TRANSACTION_AUTH || 'https://eks-apify-service.epayco.io';
+var BASE_URL_MS_TRANSACTION_AUTH = process.env.BASE_URL_MS_TRANSACTION_AUTH || 'https://eks-ms-authentication-service.epayco.io';
 
 /**
  * AES-256-CBC IV literal used by ms-transaction (verified empirically: the
@@ -373,22 +374,34 @@ function resolveIp(options) {
  * Bearer token. Not cached: the JWT is short-lived (~30min), so callers
  * re-login per request, matching what was verified empirically.
  *
+ * Uses the OAuth2 client_credentials flow against
+ * eks-ms-authentication-service.epayco.io (replacing the earlier Basic-auth
+ * login against eks-apify-service.epayco.io -- same merchant apiKey/privateKey,
+ * just sent as client_id/client_secret in a JSON body instead of a Basic
+ * header, and the returned JWT is nested under `data.token` instead of a
+ * top-level `token`). Verified empirically to produce a Bearer token that
+ * apiflow.epayco.io/payment/api/v1/transactions accepts identically to the
+ * previous host's token.
+ *
  * @param {String} apiKey
  * @param {String} privateKey
  * @return {Promise<String>} JWT
  */
 function login(apiKey, privateKey) {
-    var basicToken = CryptoJS.enc.Base64.stringify(CryptoJS.enc.Utf8.parse(apiKey + ':' + privateKey));
-    return fetch(BASE_URL_MS_TRANSACTION_AUTH + '/login', {
+    return fetch(BASE_URL_MS_TRANSACTION_AUTH + '/api/v2/auth/login', {
         method: 'POST',
         timeout: REQUEST_TIMEOUT_MS,
         headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Basic ' + basicToken
-        }
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+            client_id: apiKey,
+            client_secret: privateKey,
+            grant_type: 'client_credentials'
+        })
     })
         .then(function (res) { return res.json(); })
-        .then(function (json) { return json && json.token; });
+        .then(function (json) { return json && json.data && json.data.token; });
 }
 
 /**


### PR DESCRIPTION
## Ticket

[SDK-1352](https://epayco.atlassian.net/browse/SDK-1352) — sigue la migración de cash a ms-transaction (ya mergeada en `develop` vía #67/#68).

## Qué cambia

Reemplaza el login Basic contra `eks-apify-service.epayco.io/login` por el flujo OAuth2 `client_credentials`
contra `eks-ms-authentication-service.epayco.io/api/v2/auth/login`, a pedido explícito:

```bash
curl --location 'https://eks-ms-authentication-service.epayco.io/api/v2/auth/login' \
  --header 'Content-Type: application/json' \
  --data '{
    "client_id": "<publicKey>",
    "client_secret": "<privateKey>",
    "grant_type": "client_credentials"
  }'
```

Mismo `apiKey`/`privateKey` del comercio, ahora como `client_id`/`client_secret` en un body JSON en vez de un
header `Basic`. El JWT devuelto viene anidado en `data.token` (no en un `token` de nivel raíz como el host
anterior) — ajustado en `login()`.

Verificado empíricamente de punta a punta contra el ambiente real: el JWT del nuevo host es aceptado igual por
`apiflow.epayco.io/payment/api/v1/transactions`, tanto para `cash.create()` como `cash.get()`, pasando por el
reshaping a formato legado que ya vive en este branch (`mapToLegacyShape`, mergeado en #67/#68).

## Quality Gate

| Check | Resultado |
|---|---|
| BUILD | N/A |
| LINT | N/A |
| TESTS | ⚠️ No hay tests automatizados para `msTransactionCash.js` en `develop` ahora mismo (la carpeta `tests/` fue revertida a su estado original en un commit previo de este mismo ticket) — validado solo en vivo, ver abajo |
| SECURITY | N/A para este cambio puntual (mismo esquema de cifrado/timeout ya revisado en #67; el cambio aquí es solo el host/forma de la llamada de login) |
| QA FUNCIONAL | ✅ Validado en vivo contra el ambiente real (`eks-ms-authentication-service.epayco.io` + `apiflow.epayco.io`): `cash.create('gana', ...)` y `cash.get(refPayco)` exitosos de punta a punta |

## Nota

Esta rama sale de `develop` (no de la rama ya mergeada `fix/SDK-1352-migracion-efectivo-node`, que quedó cerrada
tras #67/#68) para no reabrir un PR ya mergeado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDK-1352]: https://epayco.atlassian.net/browse/SDK-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ