### PR TITLE
feat(SDK-1354): migrar SafetyPay al nuevo flujo ms-transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,3 +740,15 @@ epayco.safetypay.create(body)
         console.log("err: "+ err);
     })
 ```
+
+#### Retrieve
+
+```javascript
+epayco.safetypay.get("refPayco")
+    .then(function(safetypay) {
+        console.log(safetypay);
+    })
+    .catch(function(err) {
+        console.log("err: " + err);
+    });
+```

--- a/lib/gateways/msTransactionSafetypay.js
+++ b/lib/gateways/msTransactionSafetypay.js
@@ -1,0 +1,578 @@
+/**
+ * Gateway for the new "ms-transaction" microservice (apiflow.epayco.io) used to
+ * create/query SafetyPay transactions, replacing the legacy apify flow used by
+ * lib/resources/safetypay.js (`POST /payment/process/safetypay` against
+ * BASE_URL_APIFY, i.e. the pre-SDK-1354 `Resource#request(..., apify = true)`
+ * call).
+ *
+ * Mirrors lib/gateways/msTransactionBank.js (SDK-1355) and
+ * lib/gateways/msTransactionCash.js (SDK-1352) field-for-field for the
+ * encryption/auth/generic-transaction-endpoint plumbing, which is shared
+ * across every ms-transaction payment method -- only buildBody's
+ * paymentMethod/paymentMethodData and mapToLegacyShape's field mapping are
+ * SafetyPay-specific. Kept as its own self-contained module (not importing
+ * from msTransactionBank.js/msTransactionCash.js) on purpose, matching those
+ * files' own note about being independently unit-testable and isolated from
+ * Resource#request.
+ *
+ * Endpoints verified empirically against real pre-prod (merchant from
+ * epayco-node-test's .env, SDK-1354 QA):
+ *  - POST https://apiflow.epayco.io/payment/api/v1/transactions -- the
+ *    ticket's own documented endpoint
+ *    (POST .../payment/api/v1/safetypay/transactions) returned a plain 404
+ *    ("404 page not found"); the SAME generic transactions endpoint
+ *    msTransactionBank.js/msTransactionCash.js already use, with
+ *    paymentMethod "SP", returned 200 with a real SafetyPay checkout URL.
+ *  - GET https://apiflow.epayco.io/payment/api/v1/transactions/{refPayco} --
+ *    same story: the ticket's documented query endpoint
+ *    (GET .../v1/safetypay/transactions?ref_payco={id}) also 404s; this
+ *    generic per-refPayco endpoint (identical to Bank's/Cash's getTransaction)
+ *    returned the transaction. Also matches the already-shipped Python SDK's
+ *    own ms-transaction migration (epayco-python,
+ *    epaycosdk/gateways/ms_transaction.py's MsTransactionGateway, which uses
+ *    this exact same generic TRANSACTIONS_URL for every payment method
+ *    including safetypay) -- not guessed, corroborated by a second,
+ *    independently-migrated SDK.
+ *
+ * Module dependencies
+ */
+var CryptoJS = require('crypto-js');
+var fetch = require('node-fetch');
+var axios = require('axios');
+var EpaycoError = require('../resources/errors');
+
+/**
+ * Default per-request timeout (ms) for both the node-fetch and axios calls
+ * this module makes (login, create, get).
+ */
+var REQUEST_TIMEOUT_MS = 10000;
+
+/**
+ * Base hosts (env-overridable), same hosts msTransactionBank.js/
+ * msTransactionCash.js use -- SafetyPay goes through the same generic
+ * ms-transaction transactions endpoint, only paymentMethod/paymentMethodData
+ * differ (verified empirically, see this file's header note).
+ */
+var BASE_URL_MS_TRANSACTION = process.env.BASE_URL_MS_TRANSACTION || 'https://apiflow.epayco.io';
+var BASE_URL_MS_TRANSACTION_AUTH = process.env.BASE_URL_MS_TRANSACTION_AUTH || 'https://eks-apify-service.epayco.io';
+
+/**
+ * AES-256-CBC IV literal used by ms-transaction. See msTransactionBank.js's
+ * identical constant for the full rationale -- required as-is by the backend.
+ */
+var IV_STRING = '0000000000000000';
+
+/**
+ * Legacy `country` option (ISO alpha-2, e.g. "CO") -> the ISO alpha-3 code
+ * ms-transaction's `paymentMethodData.country` field requires for SafetyPay
+ * specifically (verified empirically: "CO" is rejected with "El campo
+ * country no es válido.", "COL" succeeds). Only Colombia confirmed directly
+ * against the real API here; the "CO"->"COL" entry mirrors the already-
+ * shipped Python SDK's own ms-transaction migration
+ * (epayco-python, epaycosdk/mappers/safetypay.py's `SafetypayRequestMapper.
+ * _ISO_ALPHA3`, which has the exact same single-entry map) -- corroborated,
+ * not guessed. Other SafetyPay countries (Peru, Mexico, etc.) are NOT in
+ * Python's map either, so this SDK doesn't invent them; falls back to the
+ * plain `country` value unchanged for anything not in this map (same
+ * fallback Python's mapper uses).
+ */
+var ISO_ALPHA3_BY_ALPHA2 = { CO: 'COL' };
+
+/**
+ * @param {String} country ISO alpha-2 country code (legacy `options.country`)
+ * @return {String} ISO alpha-3 equivalent if known, otherwise `country` as-is
+ */
+function toIsoAlpha3(country) {
+    return ISO_ALPHA3_BY_ALPHA2[country] || country;
+}
+
+/**
+ * Guard against a misconfigured merchant key silently producing wrong
+ * ciphertext (see msTransactionBank.js assertValidPrivateKey).
+ *
+ * @param {String} privateKey
+ * @param {String} [lang] ES or EN, defaults to ES.
+ */
+function assertValidPrivateKey(privateKey, lang) {
+    if (typeof privateKey !== 'string' || Buffer.byteLength(privateKey, 'utf8') !== 32) {
+        throw new EpaycoError(lang || 'ES', 103);
+    }
+}
+
+/**
+ * Encrypt a single value with AES-256-CBC/PKCS7. See
+ * msTransactionBank.js encryptValue for the full rationale.
+ *
+ * @param {*} value
+ * @param {String} privateKey
+ * @param {String} [lang] see assertValidPrivateKey
+ * @return {String} base64 ciphertext
+ */
+function encryptValue(value, privateKey, lang) {
+    assertValidPrivateKey(privateKey, lang);
+    var text = typeof value === 'string' ? value : JSON.stringify(value);
+    var key = CryptoJS.enc.Utf8.parse(privateKey);
+    var iv = CryptoJS.enc.Utf8.parse(IV_STRING);
+    var encrypted = CryptoJS.AES.encrypt(text, key, {
+        iv: iv,
+        mode: CryptoJS.mode.CBC,
+        padding: CryptoJS.pad.Pkcs7
+    });
+    return encrypted.ciphertext.toString(CryptoJS.enc.Base64);
+}
+
+/**
+ * base64(IV_STRING), sent as the "i" field on every request.
+ */
+function ivBase64() {
+    return CryptoJS.enc.Utf8.parse(IV_STRING).toString(CryptoJS.enc.Base64);
+}
+
+/**
+ * Recursively encrypt every leaf value of a plain object, preserving shape.
+ * publicKey stays plaintext, null/undefined leaves are omitted.
+ *
+ * @param {Object} obj
+ * @param {String} privateKey
+ * @param {String} [lang] see assertValidPrivateKey
+ * @return {Object}
+ */
+function encryptObject(obj, privateKey, lang) {
+    var out = {};
+    Object.keys(obj).forEach(function (key) {
+        var value = obj[key];
+        if (value === null || value === undefined) {
+            return;
+        }
+        if (key === 'publicKey') {
+            out[key] = value;
+            return;
+        }
+        if (typeof value === 'object' && !Array.isArray(value)) {
+            out[key] = encryptObject(value, privateKey, lang);
+            return;
+        }
+        out[key] = encryptValue(value, privateKey, lang);
+    });
+    return out;
+}
+
+/**
+ * Encrypt a full ms-transaction request body. See
+ * msTransactionBank.js encryptBody for the full rationale.
+ *
+ * @param {Object} body plaintext body (see buildBody)
+ * @param {String} privateKey
+ * @param {String} [lang] see assertValidPrivateKey
+ * @return {Object}
+ */
+function encryptBody(body, privateKey, lang) {
+    var encrypted = encryptObject(body, privateKey, lang);
+    encrypted.i = ivBase64();
+    encrypted.language = encryptValue('node', privateKey, lang);
+    return encrypted;
+}
+
+/**
+ * Bucket the legacy extra1..extra6 options into the extras object the new
+ * contract expects.
+ *
+ * @param {Object} options
+ * @return {Object}
+ */
+function buildExtras(options) {
+    var extras = {};
+    ['extra1', 'extra2', 'extra3', 'extra4', 'extra5', 'extra6'].forEach(function (key) {
+        if (options[key] !== undefined && options[key] !== null) {
+            extras[key] = options[key];
+        }
+    });
+    return extras;
+}
+
+/**
+ * Whether options carries any of the legacy split-payment fields. See
+ * msTransactionBank.js hasSplitPaymentOptions.
+ *
+ * @param {Object} options
+ * @return {Boolean}
+ */
+function hasSplitPaymentOptions(options) {
+    return !!(options.splitpayment || options.split_app_id || options.split_merchant_id ||
+        options.split_type || options.split_primary_receiver || options.split_primary_receiver_fee ||
+        options.split_rule || options.split_receivers);
+}
+
+/**
+ * Accept split_receivers as either a JSON string or an already-parsed
+ * array. See msTransactionBank.js parseSplitReceivers.
+ *
+ * @param {String|Array} splitReceivers
+ * @return {Array|undefined}
+ */
+function parseSplitReceivers(splitReceivers) {
+    if (splitReceivers === undefined || splitReceivers === null) {
+        return undefined;
+    }
+    if (typeof splitReceivers === 'string') {
+        try {
+            return JSON.parse(splitReceivers);
+        } catch (e) {
+            return splitReceivers;
+        }
+    }
+    return splitReceivers;
+}
+
+/**
+ * Map the legacy snake_case split-payment options into the root-level
+ * splitPayment object ms-transaction expects -- same convention Bank's/
+ * Cash's buildSplitPayment use, and the same shape the already-shipped
+ * Python SDK's SafetypayRequestMapper builds from `options["split_payment"]`.
+ *
+ * @param {Object} options caller-supplied options (legacy field names)
+ * @return {Object|undefined}
+ */
+function buildSplitPayment(options) {
+    if (!hasSplitPaymentOptions(options)) {
+        return undefined;
+    }
+    return {
+        splitMethod: 'multiple',
+        splitAppId: options.split_app_id,
+        splitMerchantId: options.split_merchant_id,
+        splitType: options.split_type || '02',
+        splitPrimaryReceiver: options.split_primary_receiver,
+        splitPrimaryReceiverFee: options.split_primary_receiver_fee !== undefined ? options.split_primary_receiver_fee : '0',
+        splitRule: options.split_rule || 'multiple',
+        splitReceivers: parseSplitReceivers(options.split_receivers) || []
+    };
+}
+
+/**
+ * Map the legacy safetypay.create(options) options (README's Safetypay
+ * section) into the ms-transaction plaintext body shape verified against the
+ * real API (see this file's header note).
+ *
+ * `document` (NOT `doc_number` like Bank's/Cash's `options.doc_number`) is
+ * SafetyPay's own documented legacy field name for this -- see README.md's
+ * Safetypay example (`document: "123456789"`) and
+ * `lib/keylang_apify.json`'s `"doc_number": "document"` entry (the legacy
+ * apify flow's field translator, which only fires if the caller happens to
+ * use `doc_number` instead -- both end up meaning the same thing today).
+ * `options.doc_number` is still accepted as a fallback for callers migrating
+ * from Bank's/Cash's naming convention, but `options.document` takes
+ * precedence to match the documented/legacy convention.
+ *
+ * `paymentMethodData.country` uses the ISO alpha-3 code (see toIsoAlpha3)
+ * SafetyPay's ms-transaction integration requires, while the root-level
+ * `country` field keeps the plain ISO alpha-2 value every other
+ * ms-transaction payment method uses -- both confirmed empirically to be
+ * required as different formats for this one field.
+ *
+ * `confirmationMethod` defaults to "POST" (NOT "GET" like Bank's/Cash's
+ * buildBody) -- matches the already-shipped Python SDK's SafetypayRequestMapper
+ * default. Still fully overridable via `options.method_confirmation`/
+ * `options.metodoconfirmacion` either way.
+ *
+ * `extrasEpayco.extra5` is set to "P44", matching Bank's/Cash's buildBody
+ * (msTransactionBank.js/msTransactionCash.js) -- this literal is an
+ * internal-tracking marker for this SDK's own legacy-POST traffic, not
+ * something specific to any one payment method: lib/resources/index.js's
+ * Resource#request auto-injects `{extra5: "P44"}` on every legacy POST
+ * regardless of payment method (see lib/resources/index.js:39), and both
+ * Bank's and Cash's already-merged ms-transaction migrations (SDK-1355,
+ * SDK-1352) replicate that same literal explicitly for exactly that reason.
+ * The already-shipped Python SDK uses "P43" here instead, but that is just
+ * that other codebase's own convention -- it uses "P43" uniformly for every
+ * migrated method there (including cash/PSE, where this Node repo uses
+ * "P44"), so it is not a precedent applicable to this repo. Resolved by
+ * consistency with this repo's own Bank/Cash migrations, not left pending.
+ *
+ * @param {Object} epaycoCtx the Epayco instance (apiKey/privateKey/test)
+ * @param {Object} options caller-supplied options (legacy field names)
+ * @return {Object} plaintext ms-transaction body
+ */
+function buildBody(epaycoCtx, options) {
+    options = options || {};
+    var country = options.country || 'CO';
+    var body = {
+        invoice: options.invoice,
+        quotes: '1',
+        documentType: options.doc_type,
+        document: options.document || options.doc_number,
+        names: options.name,
+        lastNames: options.last_name,
+        phone: options.phone,
+        cellphone: options.cell_phone,
+        address: options.address,
+        city: options.city,
+        email: options.email,
+        amount: options.value,
+        tax: options.tax !== undefined ? options.tax : 0,
+        ico: options.ico !== undefined ? options.ico : 0,
+        baseTax: options.tax_base !== undefined ? options.tax_base : 0,
+        currency: options.currency || 'COP',
+        testMode: epaycoCtx.test === 'TRUE',
+        uniqueTransactionPerBill: options.unique_transaction_per_bill === true,
+        paymentMethod: 'SP',
+        country: country,
+        ip: options.ip,
+        responseUrl: options.url_response || null,
+        confirmationUrl: options.url_confirmation || null,
+        confirmationMethod: options.method_confirmation || options.metodoconfirmacion || 'POST',
+        description: options.description,
+        integrationType: { tipo_checkout: 'smart_checkout', modo_pago: 'safetypay' },
+        publicKey: epaycoCtx.apiKey,
+        extras: buildExtras(options),
+        extrasEpayco: Object.assign({ extra1: '', extra2: '', extra3: '' }, options.extrasEpayco, { extra5: 'P44' }),
+        paymentMethodData: {
+            country: toIsoAlpha3(country),
+            expirationDate: options.end_date
+        }
+    };
+    var splitPayment = buildSplitPayment(options);
+    if (splitPayment) {
+        body.splitPayment = splitPayment;
+    }
+    return body;
+}
+
+/**
+ * Resolve the client IP. See msTransactionBank.js resolveIp.
+ *
+ * @param {Object} options
+ * @return {Promise<String|undefined>}
+ */
+function resolveIp(options) {
+    if (options && options.ip) {
+        return Promise.resolve(options.ip);
+    }
+    return fetch('https://api.ipify.org?format=json', { timeout: REQUEST_TIMEOUT_MS })
+        .then(function (response) { return response.json(); })
+        .then(function (data) { return data.ip; })
+        .catch(function () { return undefined; });
+}
+
+/**
+ * Log in against the ms-transaction auth host. See msTransactionBank.js login.
+ *
+ * @param {String} apiKey
+ * @param {String} privateKey
+ * @return {Promise<String>} JWT
+ */
+function login(apiKey, privateKey) {
+    var basicToken = CryptoJS.enc.Base64.stringify(CryptoJS.enc.Utf8.parse(apiKey + ':' + privateKey));
+    return fetch(BASE_URL_MS_TRANSACTION_AUTH + '/login', {
+        method: 'POST',
+        timeout: REQUEST_TIMEOUT_MS,
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Basic ' + basicToken
+        }
+    })
+        .then(function (res) { return res.json(); })
+        .then(function (json) { return json && json.token; });
+}
+
+/**
+ * refPayco is interpolated directly into the request path (see
+ * getTransaction below) -- validate strictly first. See
+ * msTransactionBank.js assertValidRefPayco for the full rationale.
+ *
+ * @param {String|Number} refPayco
+ * @param {String} [lang] see assertValidPrivateKey
+ */
+var REF_PAYCO_REGEX = /^[1-9][0-9]*$/;
+function assertValidRefPayco(refPayco, lang) {
+    var isPlainPositiveInteger = (typeof refPayco === 'string' || typeof refPayco === 'number') &&
+        REF_PAYCO_REGEX.test(String(refPayco));
+    if (!isPlainPositiveInteger) {
+        throw new EpaycoError(lang || 'ES', 103);
+    }
+}
+
+/**
+ * Map a successful ms-transaction response into the exact response shape the
+ * legacy apify safetypay endpoint returns today (see
+ * lib/resources/safetypay.js pre-SDK-1354 `.create()`), so callers get the
+ * identical shape regardless of which backend actually served the request --
+ * mirrors msTransactionBank.js/msTransactionCash.js mapToLegacyShape.
+ *
+ * Verified field-by-field against a REAL PAIRED CALL to both backends
+ * (SDK-1354 QA, epayco-node-test's real test merchant/keys): the legacy
+ * apify endpoint's actual response shape is camelCase already (`titleResponse`,
+ * `textResponse`, `lastAction`, `data.refPayco`, etc) -- NOT the
+ * snake_case/Spanish shape Bank's/Cash's truly-legacy secure.payco.co
+ * endpoints return (`title_response`, `ref_payco`, `valor`...). This is
+ * consistent with `lib/resources/safetypay.js`'s pre-SDK-1354 `.create()`
+ * already going through the `apify = true` flow (BASE_URL_APIFY,
+ * `eks-apify-service.epayco.io`) rather than the older `secure.payco.co`
+ * flow Bank/Cash used pre-migration.
+ *
+ * Also cross-checked against the already-shipped Python SDK's own
+ * ms-transaction migration for safetypay (epayco-python,
+ * epaycosdk/mappers/safetypay.py's `SafetypayResponseMapper`), which maps
+ * the exact same new-response fields into the exact same legacy field names
+ * used below -- independent corroboration, not just this one paired call.
+ *
+ * `autorization` (sic, matches the real legacy response's own typo -- single
+ * "h") is read from `data.authorization`.
+ *
+ * `transactionId` and `ticketId` are both read from `data.refPayco`/
+ * `data.receipt` respectively: the real paired legacy response showed
+ * `transactionId` === `refPayco` and `ticketId` === `recibo`/`receipt`
+ * (all matching values), same relationship Bank's mapToLegacyShape found for
+ * its own `transactionID`/`ticketId` fields (see msTransactionBank.js).
+ *
+ * `country` has NO equivalent in the ms-transaction response's `data` object
+ * (only inside the masked `payerInformation.country`, e.g. "C*") -- read
+ * from the original caller-supplied `options` instead, same rationale
+ * Bank's/Cash's mapToLegacyShape use for PII fields.
+ *
+ * `codResponse`/`codError`: the real legacy response has BOTH fields, empty
+ * strings in the one successful paired call observed (no real error-path
+ * example captured to disambiguate them further). Mapped per the
+ * already-shipped Python SDK's SafetypayResponseMapper: `codResponse` reads
+ * `data.responseCode` (the new flow's own error/status code, e.g. "P004"),
+ * `codError` is always "" (no equivalent field identified in the new
+ * response) -- not guessed independently, matches that verified precedent.
+ *
+ * @param {Object} raw ms-transaction response body ({success, message, data})
+ * @param {Object} options the original caller-supplied options
+ * @return {Object} legacy-shaped response
+ */
+function mapToLegacyShape(raw, options) {
+    options = options || {};
+    var success = !!raw.success;
+    var data = raw.data || {};
+    var providerData = data.paymentProviderData;
+    if (!providerData || Array.isArray(providerData)) {
+        providerData = {};
+    }
+    var extrasEpaycoNew = data.extrasEpayco || {};
+    return {
+        success: success,
+        titleResponse: success ? 'Ok' : (raw.message || 'Error'),
+        textResponse: raw.message,
+        lastAction: 'Envio Transaction Safetypay',
+        data: {
+            refPayco: data.refPayco,
+            invoice: data.invoice,
+            description: data.description,
+            value: data.amount,
+            tax: data.tax,
+            ico: data.ico,
+            taxBase: data.taxBase,
+            currency: data.currency,
+            status: data.status,
+            response: data.response,
+            codResponse: data.responseCode !== undefined ? data.responseCode : '',
+            codError: '',
+            autorization: data.authorization,
+            receipt: data.receipt,
+            date: data.date,
+            country: options.country || 'CO',
+            city: data.city,
+            urlBank: providerData.urlPayment || '',
+            transactionId: data.refPayco,
+            ticketId: data.receipt,
+            extras: data.extras || {},
+            extras_epayco: { extra5: extrasEpaycoNew.extra5 }
+        }
+    };
+}
+
+/**
+ * Create a SafetyPay transaction against the ms-transaction generic
+ * transactions endpoint. Resolves with the same response shape the legacy
+ * apify endpoint returns (see mapToLegacyShape) -- SDK-1354 requires callers
+ * to see one consistent shape regardless of which backend actually served
+ * the request.
+ *
+ * @param {Object} epaycoCtx the Epayco instance (apiKey/privateKey/test)
+ * @param {Object} options caller-supplied options (legacy field names)
+ * @return {Promise<Object>} legacy-shaped response (see mapToLegacyShape)
+ */
+function createTransaction(epaycoCtx, options) {
+    return resolveIp(options)
+        .then(function (ip) {
+            var body = buildBody(epaycoCtx, Object.assign({}, options, { ip: ip }));
+            var encryptedBody = encryptBody(body, epaycoCtx.privateKey, epaycoCtx.lang);
+            return login(epaycoCtx.apiKey, epaycoCtx.privateKey).then(function (token) {
+                return fetch(BASE_URL_MS_TRANSACTION + '/payment/api/v1/transactions', {
+                    method: 'POST',
+                    timeout: REQUEST_TIMEOUT_MS,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + token
+                    },
+                    body: JSON.stringify(encryptedBody)
+                });
+            });
+        })
+        .then(function (res) { return res.json(); })
+        .then(function (raw) { return mapToLegacyShape(raw, options); })
+        .catch(function (err) {
+            console.error('msTransactionSafetypay create error:', err.message);
+            return { error: err.message };
+        });
+}
+
+/**
+ * Query a SafetyPay transaction by refPayco against the ms-transaction
+ * generic transactions endpoint. Uses the SAME generic
+ * /payment/api/v1/transactions/{refPayco} endpoint Bank's/Cash's
+ * getTransaction use (see msTransactionBank.js/msTransactionCash.js) --
+ * confirmed empirically against real pre-prod: it returns 200 with the
+ * SafetyPay transaction. The `/v1/safetypay/transactions?ref_payco=...`
+ * endpoint shown in SDK-1354's Jira description returned 404 in that same
+ * test and is not used (same pattern already seen in SDK-1355's own Jira
+ * description for Bank, see msTransactionBank.js's getTransaction).
+ *
+ * @param {Object} epaycoCtx the Epayco instance (apiKey/privateKey/test)
+ * @param {String} refPayco must be a plain positive integer (see
+ *        assertValidRefPayco)
+ * @return {Promise<Object>} the ms-transaction response body as-is
+ */
+function getTransaction(epaycoCtx, refPayco) {
+    assertValidRefPayco(refPayco, epaycoCtx && epaycoCtx.lang);
+    return login(epaycoCtx.apiKey, epaycoCtx.privateKey)
+        .then(function (token) {
+            return axios({
+                url: BASE_URL_MS_TRANSACTION + '/payment/api/v1/transactions/' + encodeURIComponent(String(refPayco)),
+                method: 'get',
+                timeout: REQUEST_TIMEOUT_MS,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer ' + token
+                }
+            });
+        })
+        .then(function (result) { return result.data; })
+        .catch(function (error) {
+            var message = error.response && error.response.data && error.response.data.message
+                ? error.response.data.message
+                : error.message;
+            console.error('msTransactionSafetypay get error:', message);
+            return { error: message };
+        });
+}
+
+module.exports = {
+    BASE_URL_MS_TRANSACTION: BASE_URL_MS_TRANSACTION,
+    BASE_URL_MS_TRANSACTION_AUTH: BASE_URL_MS_TRANSACTION_AUTH,
+    ISO_ALPHA3_BY_ALPHA2: ISO_ALPHA3_BY_ALPHA2,
+    toIsoAlpha3: toIsoAlpha3,
+    encryptValue: encryptValue,
+    encryptBody: encryptBody,
+    buildBody: buildBody,
+    buildExtras: buildExtras,
+    buildSplitPayment: buildSplitPayment,
+    parseSplitReceivers: parseSplitReceivers,
+    resolveIp: resolveIp,
+    login: login,
+    mapToLegacyShape: mapToLegacyShape,
+    createTransaction: createTransaction,
+    getTransaction: getTransaction
+};

--- a/lib/resources/safetypay.js
+++ b/lib/resources/safetypay.js
@@ -3,15 +3,10 @@
  */
 var util = require('util');
 var Resource = require('./');
+var msTransactionSafetypay = require('../gateways/msTransactionSafetypay');
 
-/**
- * Expose constructor
- */
 module.exports = safetypay;
 
-/**
- * Customers constructor
- */
 function safetypay(epayco) {
     Resource.call(this, epayco);
 }
@@ -19,12 +14,53 @@ function safetypay(epayco) {
 util.inherits(safetypay, Resource);
 
 /**
- * Create Subscriptions
+ * Create a SafetyPay transaction.
+ *
+ * As of SDK-1354, this goes through the new ms-transaction microservice
+ * (apiflow.epayco.io) by default instead of the legacy apify
+ * POST /payment/process/safetypay endpoint -- see
+ * lib/gateways/msTransactionSafetypay.js for the request-building/encryption
+ * details. A merchant can opt back into the legacy backend for SafetyPay
+ * specifically by passing `transactionMethods: ["safetypay"]` to the
+ * `Epayco` constructor, mirroring the same opt-out bank.js/cash.js use for
+ * SDK-1355/SDK-1352.
+ *
+ * The public signature (`options`, legacy snake_case option names) and the
+ * resolved promise's shape (matching the legacy response, see
+ * msTransactionSafetypay.js#mapToLegacyShape) are unchanged either way.
+ *
  * @param {Object} options
  * @api public
  */
-safetypay.prototype.create = function(options) {
-    return this.request('post', '/payment/process/safetypay', options, sw = false,cashData = false,card =true,  apify = true);
+safetypay.prototype.create = function (options) {
+    if (this._epayco.usesLegacyFlow('safetypay')) {
+        return this._legacyCreate(options);
+    }
+    return msTransactionSafetypay.createTransaction(this._epayco, options);
 };
 
+/**
+ * Legacy SafetyPay creation, unchanged from the pre-SDK-1354 implementation.
+ *
+ * @param {Object} options
+ * @api private
+ */
+safetypay.prototype._legacyCreate = function (options) {
+    return this.request('post', '/payment/process/safetypay', options, sw = false, cashData = false, card = true, apify = true);
+};
 
+/**
+ * Retrieve a SafetyPay transaction by refPayco.
+ *
+ * New in SDK-1354: the pre-SDK-1354 legacy apify flow never had a query
+ * method for SafetyPay (lib/resources/safetypay.js only ever had .create()),
+ * so there is no legacy behavior to preserve here and no
+ * `transactionMethods: ["safetypay"]` opt-out for this method specifically --
+ * it always queries the ms-transaction microservice.
+ *
+ * @param {String} uid refPayco
+ * @api public
+ */
+safetypay.prototype.get = function (uid) {
+    return msTransactionSafetypay.getTransaction(this._epayco, uid);
+};

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,0 +1,36 @@
+/**
+ * Shared mocha setup, required via package.json's "test"/"coverage" scripts
+ * (`--require tests/common`). Exposes the globals every test file under
+ * tests/*.js already assumes exist (`assert`, `Epayco`, `epayco`).
+ *
+ * NOTE: package.json used to point this at `test/common` (singular `test/`),
+ * which doesn't exist in this repo (the directory is `tests/`, plural) -- so
+ * `npm test` was failing with "epayco is not defined"/"assert is not
+ * defined" for every suite before this file existed. First introduced during
+ * SDK-1352's development so `npm test` could actually validate the new cash
+ * flow, but reverted out of that PR at the time per an explicit request to
+ * keep tests/ untouched there; restored here as part of SDK-1354 because
+ * without it `npm test`/`npm run coverage` cannot even load a single test
+ * file (MODULE_NOT_FOUND), which blocks validating this ticket's own new
+ * tests/safetypay.js -- unrelated to the SafetyPay migration itself
+ * otherwise, this is just the shared scaffolding every suite needs to run.
+ */
+global.assert = require('better-assert');
+
+var Epayco = require('../lib');
+global.Epayco = Epayco;
+
+global.epayco = new Epayco({
+    apiKey: process.env.EPAYCO_TEST_PUBLIC_KEY || 'epayco-dummy-public-key-00000000',
+    // Exactly 32 UTF-8 bytes: lib/gateways/msTransactionCash.js's/
+    // msTransactionBank.js's/msTransactionSafetypay.js's assertValidPrivateKey()
+    // requires this (AES-256 key length) for every encryptBody()/encryptValue()
+    // call the ms-transaction tests exercise.
+    // Deliberately not shaped like a real provider's secret-key format
+    // (e.g. "sk_..."/"pk_...") -- an earlier version of this fixture used
+    // that shape and GitHub's push protection flagged it as a Stripe test
+    // key false positive.
+    privateKey: process.env.EPAYCO_TEST_PRIVATE_KEY || 'epayco-dummy-private-key-test000',
+    lang: 'ES',
+    test: true
+});

--- a/tests/safetypay.js
+++ b/tests/safetypay.js
@@ -1,0 +1,426 @@
+var nock = require('nock');
+var msTransactionSafetypay = require('../lib/gateways/msTransactionSafetypay');
+
+describe('Safetypay', function() {
+
+    afterEach(function() {
+        nock.cleanAll();
+    });
+
+    describe('#buildBody', function() {
+
+        it('builds the ms-transaction body from today\'s legacy option names', function() {
+            var safetypay_info = {
+                invoice: '1472050778',
+                description: 'pay test',
+                value: '20000',
+                tax: '0',
+                tax_base: '0',
+                currency: 'COP',
+                doc_type: 'CC',
+                document: '10358519',
+                name: 'testing',
+                last_name: 'PAYCO',
+                email: 'test@mailinator.com',
+                cell_phone: '3010000001',
+                city: 'Medellin',
+                country: 'CO',
+                ip: '190.0.0.1',
+                end_date: '2017-12-05',
+                url_response: 'https://example.com/response',
+                url_confirmation: 'https://example.com/confirmation',
+                extra1: 'foo'
+            };
+
+            var body = msTransactionSafetypay.buildBody(epayco, safetypay_info);
+
+            assert(body.paymentMethod === 'SP');
+            assert(body.invoice === safetypay_info.invoice);
+            assert(body.description === safetypay_info.description);
+            assert(body.amount === safetypay_info.value);
+            assert(body.documentType === safetypay_info.doc_type);
+            assert(body.document === safetypay_info.document);
+            assert(body.names === safetypay_info.name);
+            assert(body.lastNames === safetypay_info.last_name);
+            assert(body.email === safetypay_info.email);
+            assert(body.cellphone === safetypay_info.cell_phone);
+            assert(body.city === safetypay_info.city);
+            assert(body.ip === safetypay_info.ip);
+            assert(body.responseUrl === safetypay_info.url_response);
+            assert(body.confirmationUrl === safetypay_info.url_confirmation);
+            // no method_confirmation/metodoconfirmacion passed: defaults to POST
+            // (NOT "GET" like Bank's/Cash's buildBody)
+            assert(body.confirmationMethod === 'POST');
+            assert(body.publicKey === epayco.apiKey);
+            assert(body.extras.extra1 === 'foo');
+            assert(body.testMode === true);
+            // root-level country stays plain ISO alpha-2 ...
+            assert(body.country === 'CO');
+            // ... while paymentMethodData.country is the ISO alpha-3 SafetyPay needs
+            assert(body.paymentMethodData.country === 'COL');
+            assert(body.paymentMethodData.expirationDate === safetypay_info.end_date);
+            // internal-tracking marker: "P44", matching Bank's/Cash's buildBody
+            // (NOT "P43" like the Python SDK's own SafetyPay migration)
+            assert(body.extrasEpayco.extra5 === 'P44');
+        });
+
+        it('falls back to doc_number when document is not provided', function() {
+            var body = msTransactionSafetypay.buildBody(epayco, {
+                invoice: '1',
+                value: '1000',
+                doc_number: '999888777'
+            });
+            assert(body.document === '999888777');
+        });
+
+        it('prefers document over doc_number when both are provided', function() {
+            var body = msTransactionSafetypay.buildBody(epayco, {
+                invoice: '1',
+                value: '1000',
+                document: '111',
+                doc_number: '222'
+            });
+            assert(body.document === '111');
+        });
+
+        it('defaults confirmationMethod to POST but stays overridable', function() {
+            var body = msTransactionSafetypay.buildBody(epayco, {
+                invoice: '1',
+                value: '1000',
+                method_confirmation: 'GET'
+            });
+            assert(body.confirmationMethod === 'GET');
+        });
+
+        it('does not add a splitPayment block when no split-payment options are passed', function() {
+            var body = msTransactionSafetypay.buildBody(epayco, {
+                invoice: '1',
+                value: '1000'
+            });
+            assert(body.splitPayment === undefined);
+        });
+
+        it('builds a splitPayment block for a Split 1-1 request (no split_receivers)', function() {
+            var split_info = {
+                invoice: '1472050778',
+                value: '20000',
+                splitpayment: 'true',
+                split_app_id: 'P_CUST_ID_CLIENTE APPLICATION',
+                split_merchant_id: 'P_CUST_ID_CLIENTE COMMERCE',
+                split_type: '02',
+                split_primary_receiver: 'P_CUST_ID_CLIENTE APPLICATION',
+                split_primary_receiver_fee: '10'
+            };
+
+            var body = msTransactionSafetypay.buildBody(epayco, split_info);
+
+            assert(body.splitPayment);
+            assert(body.splitPayment.splitMethod === 'multiple');
+            assert(body.splitPayment.splitAppId === split_info.split_app_id);
+            assert(body.splitPayment.splitMerchantId === split_info.split_merchant_id);
+            assert(body.splitPayment.splitType === '02');
+            assert(body.splitPayment.splitPrimaryReceiver === split_info.split_primary_receiver);
+            assert(body.splitPayment.splitPrimaryReceiverFee === '10');
+            assert(body.splitPayment.splitRule === 'multiple');
+            assert('splitReceivers' in body.splitPayment);
+            assert(Array.isArray(body.splitPayment.splitReceivers));
+            assert(body.splitPayment.splitReceivers.length === 0);
+        });
+
+        it('builds a splitPayment block for a Split Multiple request (JSON-string split_receivers)', function() {
+            var receivers = [
+                { id: 'P_CUST_ID_CLIENTE 1ST RECEIVER', total: '58000', iva: '8000', baseTax: '50000', fee: '10' },
+                { id: 'P_CUST_ID_CLIENTE 2ND RECEIVER', total: '58000', iva: '8000', baseTax: '50000', fee: '10' }
+            ];
+            var split_payment_info = {
+                invoice: '1472050778',
+                value: '20000',
+                splitpayment: 'true',
+                split_app_id: 'P_CUST_ID_CLIENTE APPLICATION',
+                split_merchant_id: 'P_CUST_ID_CLIENTE COMMERCE',
+                split_type: '02',
+                split_primary_receiver: 'P_CUST_ID_CLIENTE APPLICATION',
+                split_primary_receiver_fee: '0',
+                split_rule: 'multiple',
+                split_receivers: JSON.stringify(receivers)
+            };
+
+            var body = msTransactionSafetypay.buildBody(epayco, split_payment_info);
+
+            assert(body.splitPayment);
+            assert(body.splitPayment.splitReceivers.length === 2);
+            assert(body.splitPayment.splitReceivers[0].id === receivers[0].id);
+
+            // also accept an already-parsed array (not just a JSON string)
+            var bodyFromArray = msTransactionSafetypay.buildBody(epayco, Object.assign({}, split_payment_info, { split_receivers: receivers }));
+            assert(bodyFromArray.splitPayment.splitReceivers.length === 2);
+        });
+    });
+
+    describe('#toIsoAlpha3', function() {
+        it('maps the verified "CO" -> "COL" entry', function() {
+            assert(msTransactionSafetypay.toIsoAlpha3('CO') === 'COL');
+        });
+
+        it('falls back to the plain value for any country not in the map', function() {
+            assert(msTransactionSafetypay.toIsoAlpha3('PE') === 'PE');
+            assert(msTransactionSafetypay.toIsoAlpha3('MX') === 'MX');
+        });
+    });
+
+    describe('#encryptBody', function() {
+        it('encrypts every leaf value except publicKey, and adds i/language', function() {
+            var body = msTransactionSafetypay.buildBody(epayco, {
+                invoice: '123',
+                value: '20000',
+                document: '10358519'
+            });
+            var encrypted = msTransactionSafetypay.encryptBody(body, epayco.privateKey);
+
+            assert(encrypted.publicKey === epayco.apiKey);
+            assert(typeof encrypted.invoice === 'string');
+            assert(encrypted.invoice !== body.invoice);
+            assert(typeof encrypted.paymentMethodData.country === 'string');
+            assert(encrypted.paymentMethodData.country !== body.paymentMethodData.country);
+            assert(typeof encrypted.i === 'string');
+            assert(typeof encrypted.language === 'string');
+            // null/undefined leaves (e.g. unset "city") must be omitted, not sent as "null"
+            assert(encrypted.city === undefined);
+        });
+    });
+
+    describe('#mapToLegacyShape', function() {
+        it('maps a successful ms-transaction response into the legacy shape', function() {
+            var raw = {
+                success: true,
+                message: 'Transaccion creada exitosamente',
+                data: {
+                    refPayco: 1000008905,
+                    invoice: '1472050778',
+                    description: 'pay test',
+                    amount: '20000',
+                    tax: '0',
+                    ico: '0',
+                    taxBase: '0',
+                    currency: 'COP',
+                    status: 'Pendiente',
+                    response: 'Pendiente',
+                    responseCode: 'P004',
+                    authorization: 'auth-123',
+                    receipt: 'recibo-456',
+                    date: '2026-09-10',
+                    city: 'Medellin',
+                    extrasEpayco: { extra5: 'P44' },
+                    paymentProviderData: { urlPayment: 'https://safetypay.example.com/checkout/abc' }
+                }
+            };
+
+            var mapped = msTransactionSafetypay.mapToLegacyShape(raw, { country: 'CO' });
+
+            assert(mapped.success === true);
+            assert(mapped.titleResponse === 'Ok');
+            assert(mapped.textResponse === raw.message);
+            assert(mapped.data.refPayco === raw.data.refPayco);
+            assert(mapped.data.transactionId === raw.data.refPayco);
+            assert(mapped.data.ticketId === raw.data.receipt);
+            assert(mapped.data.receipt === raw.data.receipt);
+            assert(mapped.data.autorization === raw.data.authorization);
+            assert(mapped.data.codResponse === raw.data.responseCode);
+            assert(mapped.data.codError === '');
+            assert(mapped.data.country === 'CO');
+            assert(mapped.data.urlBank === raw.data.paymentProviderData.urlPayment);
+            assert(mapped.data.extras_epayco.extra5 === 'P44');
+        });
+
+        it('maps a failed ms-transaction response, defaulting missing fields safely', function() {
+            var raw = { success: false, message: 'Invalid document', data: {} };
+            var mapped = msTransactionSafetypay.mapToLegacyShape(raw, {});
+
+            assert(mapped.success === false);
+            assert(mapped.titleResponse === raw.message);
+            assert(mapped.data.urlBank === '');
+            assert(mapped.data.codResponse === '');
+            assert(mapped.data.codError === '');
+            assert(mapped.data.country === 'CO');
+        });
+    });
+
+    describe('#create', function() {
+        it('creates a SafetyPay transaction against the ms-transaction endpoints (mocked)', function(done) {
+            nock('https://eks-apify-service.epayco.io')
+                .post('/login')
+                .reply(200, { token: 'fake.jwt.token' });
+
+            nock('https://apiflow.epayco.io')
+                .post('/payment/api/v1/transactions')
+                .reply(200, {
+                    success: true,
+                    message: 'Transaccion creada exitosamente',
+                    data: {
+                        refPayco: 1000008905,
+                        invoice: '1472050778',
+                        status: 'Pendiente',
+                        paymentProviderData: { urlPayment: 'https://safetypay.example.com/checkout/abc' }
+                    }
+                });
+
+            var safetypay_info = {
+                invoice: '1472050778',
+                description: 'pay test',
+                value: '20000',
+                document: '10358519',
+                name: 'testing',
+                last_name: 'PAYCO',
+                email: 'test@mailinator.com',
+                country: 'CO',
+                ip: '190.0.0.1'
+            };
+
+            epayco.safetypay.create(safetypay_info)
+                .then(function(safetypay) {
+                    assert(safetypay);
+                    assert(safetypay.success === true);
+                    assert(safetypay.data.refPayco === 1000008905);
+                    assert(safetypay.data.urlBank === 'https://safetypay.example.com/checkout/abc');
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('resolves with the gateway\'s error response as-is instead of rejecting', function(done) {
+            nock('https://eks-apify-service.epayco.io')
+                .post('/login')
+                .reply(200, { token: 'fake.jwt.token' });
+
+            nock('https://apiflow.epayco.io')
+                .post('/payment/api/v1/transactions')
+                .reply(400, { success: false, message: 'Invalid document' });
+
+            epayco.safetypay.create({ invoice: '1', value: '1000', ip: '190.0.0.1' })
+                .then(function(safetypay) {
+                    assert(safetypay);
+                    assert(safetypay.success === false);
+                    done();
+                })
+                .catch(done);
+        });
+
+        // SDK-1354: usesLegacyFlow('safetypay') opt-out mirrors bank.js's/cash.js's
+        // own transactionMethods opt-out (SDK-1355/SDK-1352) -- a merchant passing
+        // transactionMethods: ["safetypay"] must still hit the legacy apify
+        // POST /payment/process/safetypay endpoint, unchanged, instead of the new
+        // ms-transaction generic transactions endpoint.
+        it('uses the legacy apify flow when transactionMethods opts safetypay out', function(done) {
+            var legacyEpayco = new Epayco({
+                apiKey: epayco.apiKey,
+                privateKey: epayco.privateKey,
+                lang: 'ES',
+                test: true,
+                transactionMethods: ['safetypay']
+            });
+
+            nock('https://eks-apify-service.epayco.io')
+                .post('/login')
+                .reply(200, { token: 'fake.jwt.token' });
+
+            var legacyScope = nock('https://eks-apify-service.epayco.io')
+                .post('/payment/process/safetypay')
+                .reply(200, { success: true, titleResponse: 'Ok' });
+
+            var msTransactionScope = nock('https://apiflow.epayco.io')
+                .post('/payment/api/v1/transactions')
+                .reply(200, { success: true });
+
+            legacyEpayco.safetypay.create({ invoice: '1', value: '1000', ip: '190.0.0.1' })
+                .then(function() {
+                    assert(legacyScope.isDone());
+                    assert(!msTransactionScope.isDone());
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
+    describe('#Retrieve', function() {
+        it('retrieves a SafetyPay transaction by refPayco (mocked)', function(done) {
+            nock('https://eks-apify-service.epayco.io')
+                .post('/login')
+                .reply(200, { token: 'fake.jwt.token' });
+
+            nock('https://apiflow.epayco.io')
+                .get('/payment/api/v1/transactions/1000008905')
+                .reply(200, {
+                    success: true,
+                    message: 'ok',
+                    data: { refPayco: 1000008905, status: 'Pendiente' }
+                });
+
+            epayco.safetypay.get('1000008905')
+                .then(function(safetypay) {
+                    assert(safetypay);
+                    assert(safetypay.success === true);
+                    assert(safetypay.data.refPayco === 1000008905);
+                    done();
+                })
+                .catch(done);
+        });
+
+        // .get() is new in SDK-1354 (the pre-SDK-1354 legacy apify flow never had
+        // a query method for SafetyPay), so there is no transactionMethods
+        // opt-out for it -- it always goes through ms-transaction, even for a
+        // merchant that opted "safetypay" out of the new create() flow.
+        it('always uses the ms-transaction flow, even when transactionMethods opts safetypay out', function(done) {
+            var legacyEpayco = new Epayco({
+                apiKey: epayco.apiKey,
+                privateKey: epayco.privateKey,
+                lang: 'ES',
+                test: true,
+                transactionMethods: ['safetypay']
+            });
+
+            nock('https://eks-apify-service.epayco.io')
+                .post('/login')
+                .reply(200, { token: 'fake.jwt.token' });
+
+            var msTransactionScope = nock('https://apiflow.epayco.io')
+                .get('/payment/api/v1/transactions/1000008905')
+                .reply(200, { success: true, data: { refPayco: 1000008905 } });
+
+            legacyEpayco.safetypay.get('1000008905')
+                .then(function(safetypay) {
+                    assert(safetypay.success === true);
+                    assert(msTransactionScope.isDone());
+                    done();
+                })
+                .catch(done);
+        });
+
+        // SDK-1354 security review precedent (see msTransactionBank.js/
+        // msTransactionCash.js's own equivalent tests): refPayco is
+        // concatenated straight into the request path in
+        // msTransactionSafetypay.getTransaction, so a malformed value must
+        // never reach the network -- it should be rejected before even the
+        // login() call.
+        it('throws before any HTTP call for a malformed uid (path traversal)', function() {
+            var loginScope = nock('https://eks-apify-service.epayco.io')
+                .post('/login')
+                .reply(200, { token: 'fake.jwt.token' });
+
+            var getScope = nock('https://apiflow.epayco.io')
+                .get(/\/payment\/api\/v1\/transactions\/.*/)
+                .reply(200, { success: true });
+
+            var threw = false;
+            try {
+                epayco.safetypay.get('1000008905/../secrets');
+            } catch (e) {
+                threw = true;
+                assert(/103/.test(e.message));
+            }
+            assert(threw);
+            assert(!loginScope.isDone());
+            assert(!getScope.isDone());
+        });
+    });
+
+});


### PR DESCRIPTION
## Ticket
[SDK-1354](https://epayco.atlassian.net/browse/SDK-1354) — Migración servicio ms-transaction-SAFETYPAY-SDK Node

## Causa raíz / contexto
Los endpoints que documenta el ticket (`POST/GET .../v1/safetypay/transactions*`) no existen contra el backend real (404 verificado empíricamente en pre-prod). El endpoint correcto es el mismo genérico `/payment/api/v1/transactions` que ya usan los flujos ya migrados de PSE (`msTransactionBank.js`, SDK-1355, PR #69) y Efectivo (`msTransactionCash.js`, SDK-1352, PR #67), con `paymentMethod: "SP"`.

## Fix
- **`lib/gateways/msTransactionSafetypay.js`** (nuevo): mismo patrón de cifrado AES-256-CBC, auth Basic→Bearer JWT y mapeo a la forma de respuesta legacy que Bank/Cash, adaptado a los campos propios de SafetyPay (`document` en vez de `doc_number`, `country` ISO alpha-3 vía `CO`→`COL`, `confirmationMethod` default `POST`).
- **`extrasEpayco.extra5 = "P44"`** (no `"P43"`): es el marcador de tracking interno que `lib/resources/index.js`'s `Resource#request` auto-inyecta en todo POST legacy de este repo, replicado explícitamente por Bank/Cash por ese mismo motivo — no un literal específico del método de pago. El SDK de Python usa `"P43"`, pero es la convención de ese otro codebase (usa `"P43"` uniformemente para todos sus métodos migrados, incluido PSE/Cash, donde este repo usa `"P44"`) — no es un precedente aplicable aquí.
- **`lib/resources/safetypay.js`**: `.create()` gana el opt-out `transactionMethods: ["safetypay"]` hacia el flujo legacy de `apify` (mismo patrón que `bank.js`/`cash.js`). `.get()` es funcionalidad nueva sin opt-out — el flujo legacy nunca tuvo consulta de transacción para SafetyPay.
- **`tests/safetypay.js`** (nuevo, 18 tests con `nock`), **`tests/common.js`** (restaurado — se había revertido antes de mergear SDK-1352 sin reemplazo, dejaba `npm test` roto para cualquier test).
- **`README.md`**: documenta `safetypay.get()`.

## Breaking changes
Ninguno. `.create()` mantiene la misma firma pública y la misma forma de respuesta (mapeada a la forma legacy). `.get()` es una API nueva (el flujo legacy nunca tuvo consulta de transacción para SafetyPay). El opt-out `transactionMethods: ["safetypay"]` permite volver al flujo legacy sin cambios de código para quien lo necesite.

## Quality Gate
- **BUILD**: N/A — SDK sin build, se consume el JS directo.
- **LINT**: N/A — sin script `lint` en `package.json`.
- **TESTS**: ✅ `npm test` (mocha) — `tests/safetypay.js` 18/18 en verde. Suite completa: 19 passing / 20 failing, los mismos 20 fallos pre-existentes (timeouts en tests legacy sin mocks de `bank.js`/`cash.js`/`charge.js`/etc., confirmado corriendo la suite sin los cambios de este PR) — ninguna falla nueva introducida.
- **SECURITY**: ✅ `security-agent` — sin hallazgos CRITICAL/HIGH. 1 MEDIUM (`login()` no valida el status HTTP antes de extraer el JWT — patrón heredado, ya presente en `msTransactionBank.js`, no introducido por este PR) y 1 LOW (mensaje de error de red se devuelve al llamador, mismo patrón que Bank/Cash) documentados, no bloqueantes — candidatos a un ticket de higiene técnico aparte que cubra los tres módulos ms-transaction a la vez.
- **QA FUNCIONAL**: N/A — `epayco-node` no tiene entorno Docker/QA configurado en este workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDK-1354]: https://epayco.atlassian.net/browse/SDK-1354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ