### PR TITLE
SDK-1352: mostrar el mensaje real de ms-transaction en respuestas fallidas de cash

### DIFF
--- a/lib/gateways/msTransactionCash.js
+++ b/lib/gateways/msTransactionCash.js
@@ -468,6 +468,30 @@ function codRespuestaFromEstado(estadoTexto) {
 }
 
 /**
+ * When ms-transaction rejects a request, the real failure detail lives in
+ * `data.errors[].message` (a ValidationException shape: `{errorType,
+ * errorTypeDescription, errors: [{code, message}]}`), not in the top-level
+ * `message` field -- that top-level `message` is a generic, unhelpful
+ * "Transaction request" for every validation failure observed. Without this,
+ * `mapToLegacyShape` (which only knows the success-path `data` shape) mapped
+ * `text_response` to that generic string and every other `data.*` field to
+ * `undefined`, silently discarding the actual reason. Found and fixed first
+ * in msTransactionSafetypay.js (SDK-1354 split-payment QA), then confirmed
+ * this file shares the exact same gap since it shares the exact same
+ * unconditional-success-shape pattern.
+ *
+ * @param {Object} raw ms-transaction response body ({success, message, data})
+ * @return {String}
+ */
+function extractErrorMessage(raw) {
+    var data = raw && raw.data;
+    if (data && Array.isArray(data.errors) && data.errors.length) {
+        return data.errors.map(function (e) { return e && e.message; }).filter(Boolean).join(' ');
+    }
+    return raw && raw.message;
+}
+
+/**
  * Map a successful ms-transaction response into the exact response shape the
  * legacy secure.payco.co/restpagos/v2/efectivo/{type} endpoint returns today
  * (see lib/resources/cash.js#_legacyCreate and tests/cash.js's "legacy flow"
@@ -509,7 +533,7 @@ function mapToLegacyShape(raw, options, type) {
     return {
         success: success,
         title_response: success ? 'SUCCESS' : 'ERROR',
-        text_response: raw.message,
+        text_response: success ? raw.message : extractErrorMessage(raw),
         last_action: 'Crear pin ' + type,
         data: {
             ref_payco: data.refPayco,


### PR DESCRIPTION
## Ticket

Sigue [SDK-1352](https://epayco.atlassian.net/browse/SDK-1352) (cash → ms-transaction, ya mergeado a `develop`).

## Qué corrige

`mapToLegacyShape()` en `lib/gateways/msTransactionCash.js` solo conocía la forma de respuesta exitosa
(`data.refPayco`, `data.invoice`, etc). Cuando ms-transaction rechaza el request, `data` tiene una forma
completamente distinta (`{errorType, errors: [{message}]}`), así que todos los campos mapeados salían
`undefined` y `text_response` quedaba con el texto genérico `"Transaction request"` — el motivo real del rechazo
se perdía por completo.

Verificado en vivo con el mismo caso de split payment que motivó este hallazgo:

**Antes:** `text_response: "Transaction request"`
**Después:** `text_response: "El valor de la transacción no concuerda a la suma del split."`

## Quality Gate

| Check | Resultado |
|---|---|
| BUILD / LINT | N/A |
| TESTS | No hay tests automatizados para este gateway ahora mismo (carpeta `tests/` revertida en un commit previo del propio SDK-1352) — validado en vivo, ver abajo |
| SECURITY | N/A — solo cambia qué texto se expone en un mensaje de error ya destinado al integrador, no cambia autenticación/cifrado |
| QA FUNCIONAL | ✅ Validado en vivo contra el ambiente real (comercio 630339): request de split payment con montos que no cuadran, antes vs después del fix (arriba) |

Mismo bug encontrado y corregido en paralelo para PSE/Bank (SDK-1355) y SafetyPay (SDK-1354) en PRs separados,
ya que los tres gateways comparten el mismo patrón de `mapToLegacyShape`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDK-1352]: https://epayco.atlassian.net/browse/SDK-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ