### PR TITLE
SDK-1355: mostrar el mensaje real de ms-transaction en respuestas fallidas de PSE

### DIFF
--- a/lib/gateways/msTransactionBank.js
+++ b/lib/gateways/msTransactionBank.js
@@ -353,6 +353,30 @@ function codRespuestaFromEstado(estadoTexto) {
 }
 
 /**
+ * When ms-transaction rejects a request, the real failure detail lives in
+ * `data.errors[].message` (a ValidationException shape: `{errorType,
+ * errorTypeDescription, errors: [{code, message}]}`), not in the top-level
+ * `message` field -- that top-level `message` is a generic, unhelpful
+ * "Transaction request" for every validation failure observed. Without this,
+ * `mapToLegacyShape` (which only knows the success-path `data` shape) mapped
+ * `text_response` to that generic string and every other `data.*` field to
+ * `undefined`, silently discarding the actual reason. Found and fixed first
+ * in msTransactionSafetypay.js (SDK-1354 split-payment QA) and
+ * msTransactionCash.js (SDK-1352); this file shares the exact same gap since
+ * it shares the exact same unconditional-success-shape pattern.
+ *
+ * @param {Object} raw ms-transaction response body ({success, message, data})
+ * @return {String}
+ */
+function extractErrorMessage(raw) {
+    var data = raw && raw.data;
+    if (data && Array.isArray(data.errors) && data.errors.length) {
+        return data.errors.map(function (e) { return e && e.message; }).filter(Boolean).join(' ');
+    }
+    return raw && raw.message;
+}
+
+/**
  * Map a successful ms-transaction response into the exact response shape the
  * legacy PSE endpoint returns today (see lib/resources/bank.js), so callers
  * get the identical shape regardless of which backend actually served the
@@ -394,7 +418,7 @@ function mapToLegacyShape(raw) {
     return {
         success: success,
         title_response: success ? 'SUCCESS' : 'ERROR',
-        text_response: raw.message,
+        text_response: success ? raw.message : extractErrorMessage(raw),
         last_action: 'get bank url',
         data: {
             ref_payco: data.refPayco,


### PR DESCRIPTION
## Ticket

Sigue [SDK-1355](https://epayco.atlassian.net/browse/SDK-1355) (PSE/Bank → ms-transaction, ya mergeado a `develop`).

## Qué corrige

Mismo bug que el fix de cash (SDK-1352) y SafetyPay (SDK-1354): `mapToLegacyShape()` en
`lib/gateways/msTransactionBank.js` solo conocía la forma de respuesta exitosa. Cuando ms-transaction rechaza el
request (forma `{errorType, errors: [{message}]}`), `text_response` quedaba con el texto genérico
`"Transaction request"` en vez del motivo real.

Verificado en vivo (mismo caso de split payment usado para cash/safetypay):

**Antes:** `text_response: "Transaction request"`
**Después:** `text_response: "El valor de la transacción no concuerda a la suma del split."`

## Quality Gate

| Check | Resultado |
|---|---|
| BUILD / LINT | N/A |
| TESTS | No hay tests automatizados para este gateway ahora mismo — validado en vivo, ver abajo |
| SECURITY | N/A — solo cambia el texto expuesto en un error, no autenticación/cifrado |
| QA FUNCIONAL | ✅ Validado en vivo contra el ambiente real (comercio 630339): request PSE de split payment con montos que no cuadran, antes vs después del fix (arriba) |

PRs hermanos: cash (#72), SafetyPay (pendiente de abrir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDK-1355]: https://epayco.atlassian.net/browse/SDK-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ