### PR TITLE
SDK-1354: mostrar el mensaje real de ms-transaction en respuestas fallidas de SafetyPay

### DIFF
--- a/lib/gateways/msTransactionSafetypay.js
+++ b/lib/gateways/msTransactionSafetypay.js
@@ -393,6 +393,34 @@ function assertValidRefPayco(refPayco, lang) {
 }
 
 /**
+ * When ms-transaction rejects a request, the real failure detail lives in
+ * `data.errors[].message` (a ValidationException shape: `{errorType,
+ * errorTypeDescription, errors: [{code, message}]}`), not in the top-level
+ * `message` field -- that top-level `message` is a generic, unhelpful
+ * "Transaction request" for every validation failure observed. Without this,
+ * `mapToLegacyShape` (which only knows the success-path `data` shape) mapped
+ * `textResponse` to that generic string and every other `data.*` field to
+ * `undefined`, silently discarding the actual reason.
+ *
+ * Verified empirically: a SafetyPay split-payment transaction rejected by the
+ * real API returned
+ * `{"message":"Transaction request","data":{"errorType":"ValidationException",
+ * "errors":[{"message":"El valor de la transacción no concuerda a la suma del
+ * split."}]}}` -- `textResponse` came back as the useless "Transaction
+ * request" before this fix.
+ *
+ * @param {Object} raw ms-transaction response body ({success, message, data})
+ * @return {String}
+ */
+function extractErrorMessage(raw) {
+    var data = raw && raw.data;
+    if (data && Array.isArray(data.errors) && data.errors.length) {
+        return data.errors.map(function (e) { return e && e.message; }).filter(Boolean).join(' ');
+    }
+    return raw && raw.message;
+}
+
+/**
  * Map a successful ms-transaction response into the exact response shape the
  * legacy apify safetypay endpoint returns today (see
  * lib/resources/safetypay.js pre-SDK-1354 `.create()`), so callers get the
@@ -454,7 +482,7 @@ function mapToLegacyShape(raw, options) {
     return {
         success: success,
         titleResponse: success ? 'Ok' : (raw.message || 'Error'),
-        textResponse: raw.message,
+        textResponse: success ? raw.message : extractErrorMessage(raw),
         lastAction: 'Envio Transaction Safetypay',
         data: {
             refPayco: data.refPayco,


### PR DESCRIPTION
## Ticket

Sigue [SDK-1354](https://epayco.atlassian.net/browse/SDK-1354) (SafetyPay → ms-transaction, PR #71 ya mergeado a
`develop`).

## Qué corrige

Este es el bug original que motivó la investigación: al probar split payment para SafetyPay, un request
rechazado por el backend real devolvía `textResponse: "Transaction request"` sin ningún detalle, mientras que la
respuesta cruda de ms-transaction sí traía el motivo real:

```json
{
  "message": "Transaction request",
  "data": {
    "errorType": "ValidationException",
    "errors": [{ "message": "El valor de la transacción no concuerda a la suma del split." }]
  }
}
```

`mapToLegacyShape()` solo conocía la forma de respuesta exitosa (`data.refPayco`, etc.), así que ante esta forma
de error todos los campos salían vacíos y el mensaje real nunca llegaba al integrador.

**Antes:** `textResponse: "Transaction request"`
**Después:** `textResponse: "El valor de la transacción no concuerda a la suma del split."`

Nota aparte (no corregida aquí, fuera de alcance de este fix puntual): durante esta misma investigación se
confirmó que el flujo legacy (apify) de SafetyPay **ignora silenciosamente** las opciones de split payment — el
request se completa igual mostrando éxito, sin aplicar ningún split. Un comercio que dependiera de split para
SafetyPay en el flujo legacy nunca lo tuvo realmente funcionando.

## Quality Gate

| Check | Resultado |
|---|---|
| BUILD / LINT | N/A |
| TESTS | No hay tests automatizados para este gateway ahora mismo — validado en vivo, ver abajo |
| SECURITY | N/A — solo cambia el texto expuesto en un error, no autenticación/cifrado |
| QA FUNCIONAL | ✅ Validado en vivo contra el ambiente real (comercio 630339): request SafetyPay de split payment con montos que no cuadran, antes vs después del fix (arriba) |

PRs hermanos: cash (#72), PSE (#73) — mismo bug, mismo fix, en los tres gateways que comparten este patrón de
`mapToLegacyShape`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDK-1354]: https://epayco.atlassian.net/browse/SDK-1354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ