### PR TITLE
SDK-1352: mover auth de cash a apiflow.epayco.io/authentication

### DIFF
--- a/lib/gateways/msTransactionCash.js
+++ b/lib/gateways/msTransactionCash.js
@@ -5,9 +5,9 @@
  *
  * Kept isolated from lib/resources/index.js (Resource#request) on purpose: this
  * flow talks to different hosts, uses a different auth handshake (OAuth2
- * client_credentials against eks-ms-authentication-service.epayco.io ->
- * short-lived JWT) and a different per-field AES-256-CBC encryption scheme
- * than the legacy secure.payco.co flow,
+ * client_credentials against apiflow.epayco.io/authentication -> short-lived
+ * JWT) and a different per-field AES-256-CBC encryption scheme than the
+ * legacy secure.payco.co flow,
  * so folding it into Resource#request's already-overloaded flag signature
  * (sw/cashData/card/apify) would make that method harder to reason about. This
  * module is also written so the pure body-building/encryption logic can be unit
@@ -35,13 +35,16 @@ var REQUEST_TIMEOUT_MS = 10000;
  *
  * NOTE: this is intentionally NOT the same host as the existing `apify` flag in
  * lib/resources/index.js (BASE_URL_APIFY, default "https://apify.epayco.co",
- * used today by safetypay.js/daviplata.js). The ms-transaction cash flow talks
- * to a different, newer host (eks-ms-authentication-service.epayco.io for
- * auth, apiflow.epayco.io for the transaction itself), verified empirically
- * against the real API.
+ * used today by safetypay.js/daviplata.js). Auth and the transaction itself
+ * are now both under apiflow.epayco.io (different paths -- see login() and
+ * createTransaction()/getTransaction() below), verified empirically against
+ * the real API. Kept as a separate constant from BASE_URL_MS_TRANSACTION
+ * (even though they resolve to the same default host today) since they are
+ * env-overridable independently and conceptually distinct (auth vs. the
+ * transactions API).
  */
 var BASE_URL_MS_TRANSACTION = process.env.BASE_URL_MS_TRANSACTION || 'https://apiflow.epayco.io';
-var BASE_URL_MS_TRANSACTION_AUTH = process.env.BASE_URL_MS_TRANSACTION_AUTH || 'https://eks-ms-authentication-service.epayco.io';
+var BASE_URL_MS_TRANSACTION_AUTH = process.env.BASE_URL_MS_TRANSACTION_AUTH || 'https://apiflow.epayco.io';
 
 /**
  * AES-256-CBC IV literal used by ms-transaction (verified empirically: the
@@ -375,20 +378,20 @@ function resolveIp(options) {
  * re-login per request, matching what was verified empirically.
  *
  * Uses the OAuth2 client_credentials flow against
- * eks-ms-authentication-service.epayco.io (replacing the earlier Basic-auth
- * login against eks-apify-service.epayco.io -- same merchant apiKey/privateKey,
- * just sent as client_id/client_secret in a JSON body instead of a Basic
- * header, and the returned JWT is nested under `data.token` instead of a
- * top-level `token`). Verified empirically to produce a Bearer token that
- * apiflow.epayco.io/payment/api/v1/transactions accepts identically to the
- * previous host's token.
+ * apiflow.epayco.io/authentication/api/v2/login (previously
+ * eks-ms-authentication-service.epayco.io/api/v2/auth/login, and before that
+ * a Basic-auth login against eks-apify-service.epayco.io -- same merchant
+ * apiKey/privateKey each time, sent as client_id/client_secret in a JSON body,
+ * JWT nested under `data.token`). Verified empirically: same request/response
+ * shape as the previous host, and the returned Bearer token is accepted
+ * identically by apiflow.epayco.io/payment/api/v1/transactions.
  *
  * @param {String} apiKey
  * @param {String} privateKey
  * @return {Promise<String>} JWT
  */
 function login(apiKey, privateKey) {
-    return fetch(BASE_URL_MS_TRANSACTION_AUTH + '/api/v2/auth/login', {
+    return fetch(BASE_URL_MS_TRANSACTION_AUTH + '/authentication/api/v2/login', {
         method: 'POST',
         timeout: REQUEST_TIMEOUT_MS,
         headers: {


### PR DESCRIPTION
## Ticket

Sigue [SDK-1352](https://epayco.atlassian.net/browse/SDK-1352) (cash → ms-transaction).

## Qué cambia

A pedido, mueve el login de `msTransactionCash.js` de:

```
POST https://eks-ms-authentication-service.epayco.io/api/v2/auth/login
```

a:

```
POST https://apiflow.epayco.io/authentication/api/v2/login
```

Mismo contrato: `client_id`/`client_secret`/`grant_type: "client_credentials"` en el body, JWT devuelto en
`data.token`. Solo cambia el host+path — ahora la autenticación y las transacciones viven bajo el mismo dominio
(`apiflow.epayco.io`).

Este endpoint solo se usa en `msTransactionCash.js` (PSE y SafetyPay siguen usando
`eks-apify-service.epayco.io`, sin cambios), así que este PR toca un único archivo/rama.

## Quality Gate

| Check | Resultado |
|---|---|
| BUILD / LINT | N/A |
| TESTS | No hay tests automatizados para este gateway ahora mismo — validado en vivo, ver abajo |
| SECURITY | N/A — mismo esquema de auth/cifrado, solo cambia el host+path del login |
| QA FUNCIONAL | ✅ Validado en vivo contra el ambiente real (comercio 630339): login exitoso contra el nuevo endpoint, `cash.create('gana', ...)` y `cash.get(refPayco)` exitosos con el Bearer resultante |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SDK-1352]: https://epayco.atlassian.net/browse/SDK-1352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ